### PR TITLE
Future-proof transform selectors

### DIFF
--- a/css/jquery.freetrans.css
+++ b/css/jquery.freetrans.css
@@ -1,3 +1,7 @@
+.ft-widget {
+	-webkit-transform-style: preserve-3d;
+}
+
 .ft-container {
 	position: absolute;
 }
@@ -6,6 +10,7 @@
 	position: absolute;
 	width: 100%;
 	height: 100%;
+	-webkit-transform-style: preserve-3d;
 }
 
 .ft-scaler {

--- a/js/jquery.freetrans.js
+++ b/js/jquery.freetrans.js
@@ -73,7 +73,9 @@
 		
 		var off = sel.offset();
 
-		sel.css({top: 0, left: 0, position: 'static'});
+		sel
+			.addClass('ft-widget')
+			.css({top: 0, left: 0, position: 'static'});
 
 		// wrap an ft-container around the selector
 		sel.wrap('<div class="ft-container"></div>');
@@ -136,12 +138,6 @@
 		if(options) {
 			_setOptions(sel.data('freetrans'), options);
 		}
-		
-
-		try {
-			controls[0].style['-webkit-transform-style'] = 'preserve-3d';
-			sel[0].style['-webkit-transform-style'] = 'preserve-3d';
-		} catch (err) {}
 
 		// translate (aka move)
 		container.bind('mousedown.freetrans', function(evt) {


### PR DESCRIPTION
This makes the plugin less dependent on UA sniffing by always using unprefixed styles (in addition to the prefixed ones). It also removes the Safari check, which used the now-removed `$.browser` making the plugin error with newer versions of jQuery. I don't think there's any harm in simply always applying that style, so I moved it into the stylesheet.
