### PR TITLE
Fix IE8 error

### DIFF
--- a/js/jquery.freetrans.js
+++ b/js/jquery.freetrans.js
@@ -437,7 +437,7 @@
         function _createStyleSetter(prop) {
                 var prefixed;
                 if (vendorPrefix) {
-                        prefixed = vendorPrefix + prop[0].toUpperCase() + prop.substr(1);
+                        prefixed = vendorPrefix + prop.substr(0, 1).toUpperCase() + prop.substr(1);
                         return function (el, value) { el.style[prefixed] = el.style[prop] = value; };
                 }
                 return function (el, value) { el.style[prop] = value; };


### PR DESCRIPTION
Can't use array indexing on strings in IE8
