### PR TITLE
Changed controls method to toggle the controls if no option is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ The `'rot-origin'` property is a string formatted just like the `'transform-orig
 
 ##### Showing/Hiding the controls
 
-You can show and hide the controls by passing `'controls'` to the plugin folloed by a boolean to either show or hide the controls.
+You can show and hide the controls by passing `'controls'` to the plugin, optionally followed by a boolean to either show or hide the controls.
 
 	// hide the controls
 	$('mydiv').freetrans('controls', false);
 
 	// show the controls
 	$('mydiv').freetrans('controls', true);
+
+        // toggle the controls
+        $('mydiv').freetrans('controls');
 
 
 

--- a/js/jquery.freetrans.js
+++ b/js/jquery.freetrans.js
@@ -449,7 +449,12 @@
         function _toggleControls(sel, show) {
                 var d = sel.data('freetrans');
                 
-                if(show == d._p.controls) return;
+                var curr_vis = d._p.controls;
+                if(typeof show == 'undefined'){
+                    show = !curr_vis; 
+                }else if(show == d._p.controls){ 
+                    return; 
+                }
 
                 d._p.divs.controls.css({
                         visibility: (show) ? 'visible' : 'hidden'


### PR DESCRIPTION
This allows toggling of the controls visibility without knowing what it's set
to currently.  My use case has the controls being hidden or shown upon double
click for a large number of elements.

Updated the README to reflect changes.
